### PR TITLE
feat: add zsh bookmark picker

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -63,3 +63,8 @@ export PATH="$PATH:$HOME/.lmstudio/bin"
 
 # Added by Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+
+# Added by LM Studio CLI (lms)
+export PATH="$PATH:/Users/arigatatsuya/.lmstudio/bin"
+# End of LM Studio CLI section
+

--- a/.zshrc
+++ b/.zshrc
@@ -63,8 +63,3 @@ export PATH="$PATH:$HOME/.lmstudio/bin"
 
 # Added by Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
-
-# Added by LM Studio CLI (lms)
-export PATH="$PATH:/Users/arigatatsuya/.lmstudio/bin"
-# End of LM Studio CLI section
-

--- a/config/zsh/bindkey.zsh
+++ b/config/zsh/bindkey.zsh
@@ -18,3 +18,6 @@ bindkey '^t' fzf-cdr
 bindkey '^G' fzf-ghq
 
 bindkey '^X' zsh_convert_all
+
+# ブックマーク picker
+bindkey '^]' bm-widget

--- a/config/zsh/env.zsh
+++ b/config/zsh/env.zsh
@@ -49,3 +49,10 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 export GHQ_ROOT="$HOME/Work/git"
 
 export PATH="$HOME/bin:$PATH"
+
+
+# ------------------------------------------------------------------------
+# knowledge
+# ------------------------------------------------------------------------
+export KNOWLEDGE_REPO_PATH="$HOME/Work/git/github.com/sk8metalme/worklog"
+export KNOWLEDGE_REPO_URL="https://github.com/sk8metalme/worklog"

--- a/config/zsh/functions.zsh
+++ b/config/zsh/functions.zsh
@@ -227,3 +227,59 @@ function git_stash_list_action() {
             ;;
     esac
 }
+
+# ~/.zshrc に追加
+bm() {
+  local bookmark_rows selected
+  bookmark_rows=$(python3 - << 'PYEOF'
+import json, os, glob
+
+bm_files = glob.glob(os.path.expanduser(
+    "~/Library/Application Support/Google/Chrome/*/Bookmarks"
+))
+
+def find(node, results):
+    if node.get("type") == "url":
+        name = node.get("name", "")
+        url = node.get("url", "")
+        display_name = name or url
+        results.append(f"{display_name}\t{url}")
+    for child in node.get("children", []):
+        find(child, results)
+
+results = []
+for bm_path in bm_files:
+    try:
+        with open(bm_path) as f:
+            data = json.load(f)
+        for root in data["roots"].values():
+            find(root, results)
+    except:
+        pass
+
+print("\n".join(results))
+PYEOF
+  )
+
+  selected=$(printf '%s\n' "$bookmark_rows" | fzf \
+      --delimiter='\t' \
+      --with-nth=1 \
+      --preview='echo {2}' \
+      --preview-window=down:1 \
+      --prompt='🔖 Bookmark > ' \
+      --height=40%
+  )
+
+  [ -z "$selected" ] && return
+  local url
+  url=$(echo "$selected" | cut -f2)
+  echo "Opening: $url"
+  cmux browser open-split "$url"
+}
+
+bm-widget() {
+  zle -I
+  bm
+  zle reset-prompt
+}
+zle -N bm-widget


### PR DESCRIPTION
## Summary
- add a `bm` zsh function and `bm-widget` for browsing Chrome bookmarks with `fzf`
- bind `Ctrl-]` to the bookmark picker widget
- add knowledge repo environment variables and update local PATH entries

## Testing
- zsh -n .zshrc
- zsh -n config/zsh/bindkey.zsh
- zsh -n config/zsh/env.zsh
- zsh -n config/zsh/functions.zsh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブックマーク選択機能を追加しました。Chrome ブックマークをインタラクティブに検索して開くことができます。
  * ブックマーク機能のキーボードショートカットを追加しました。
  * 知識リポジトリへのアクセスに必要な環境情報を新規設定しました。
  * LM Studio CLI へのパスを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->